### PR TITLE
Added Backend Functionality to Find Times to Schedule

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -20,12 +20,13 @@ const featureRoutes = require("./routes/feature");
 const cacheRoutes = require("./routes/userNews");
 const interactionRoutes = require("./routes/interactions");
 const rankingRoutes = require("./routes/rankings");
+const globalRoutes = require("./routes/globalInteractions")
 
 app.use(express.json());
 
 app.use(
   cors({
-    origin: "http://localhost:5175", // Replace with your frontend's origin
+    origin: "http://localhost:5173", // Replace with your frontend's origin
     credentials: true,
   }),
 );
@@ -59,6 +60,7 @@ app.use("/featured", featureRoutes);
 app.use("/user-news", cacheRoutes);
 app.use("/interactions", interactionRoutes);
 app.use("/ranking", rankingRoutes);
+app.use("/global", globalRoutes);
 
 app.listen(PORT, () => {});
 

--- a/backend/prisma/migrations/20250714223049_init_news/migration.sql
+++ b/backend/prisma/migrations/20250714223049_init_news/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - Added the required column `likedCount` to the `GlobalInteraction` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `publishedDate` to the `GlobalInteraction` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `readCount` to the `GlobalInteraction` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "GlobalInteraction" ADD COLUMN     "likedCount" INTEGER NOT NULL,
+ADD COLUMN     "publishedDate" TIMESTAMP(3) NOT NULL,
+ADD COLUMN     "readCount" INTEGER NOT NULL;

--- a/backend/prisma/migrations/20250714233402_init_news/migration.sql
+++ b/backend/prisma/migrations/20250714233402_init_news/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `publishedDate` on the `GlobalInteraction` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "GlobalInteraction" DROP COLUMN "publishedDate",
+ADD COLUMN     "publishedDayOfWeek" TEXT,
+ADD COLUMN     "publishedTime" TEXT;

--- a/backend/prisma/migrations/20250714233414_init_news/migration.sql
+++ b/backend/prisma/migrations/20250714233414_init_news/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - Made the column `publishedDayOfWeek` on table `GlobalInteraction` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `publishedTime` on table `GlobalInteraction` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "GlobalInteraction" ALTER COLUMN "publishedDayOfWeek" SET NOT NULL,
+ALTER COLUMN "publishedTime" SET NOT NULL;

--- a/backend/prisma/migrations/20250714233958_init_news/migration.sql
+++ b/backend/prisma/migrations/20250714233958_init_news/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - Changed the type of `publishedDayOfWeek` on the `GlobalInteraction` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- AlterTable
+ALTER TABLE "GlobalInteraction" DROP COLUMN "publishedDayOfWeek",
+ADD COLUMN     "publishedDayOfWeek" INTEGER NOT NULL;

--- a/backend/prisma/migrations/20250715050125_init_news/migration.sql
+++ b/backend/prisma/migrations/20250715050125_init_news/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - Changed the type of `publishedTime` on the `GlobalInteraction` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- AlterTable
+ALTER TABLE "GlobalInteraction" DROP COLUMN "publishedTime",
+ADD COLUMN     "publishedTime" INTEGER NOT NULL;

--- a/backend/prisma/migrations/20250715185912_init_news/migration.sql
+++ b/backend/prisma/migrations/20250715185912_init_news/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `score` to the `GlobalInteraction` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "GlobalInteraction" ADD COLUMN     "score" DOUBLE PRECISION NOT NULL;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -67,14 +67,19 @@ model News {
  sentiment Json?
  interactions UserInteraction[]
  userNewsCache UserNewsCache[]
- globalInteraction GlobalInteraction[]
+ globalInteractions GlobalInteraction[]
 }
 
-model GlobalInteraction {
+model GlobalInteraction { // aggregated engagement signals per news across users
   id       Int    @id @default(autoincrement())
   openCount Int
+  readCount Int
+  likedCount Int
+  publishedDayOfWeek Int
+  publishedTime Int // just the hour for now
   newsId Int
-  news News @relation(fields : [newsId], references : [id])
+  score Float // engagement score
+  news News @relation(fields : [newsId], references : [id]) 
 }
 
 model Ranking {

--- a/backend/routes/globalInteractions.js
+++ b/backend/routes/globalInteractions.js
@@ -1,0 +1,19 @@
+const express = require("express");
+const router = express.Router();
+
+const { PrismaClient } = require("@prisma/client");
+const prisma = new PrismaClient();
+
+// get the gloabl interactions
+router.get("/", async (req, res) => {
+    const interactions = await prisma.globalInteraction.findMany();
+    res.status(200).json(interactions);
+})
+
+// delete global interactions (testing purposes)
+router.delete("/delete", async (req, res) => {
+    const deleted = await prisma.globalInteraction.deleteMany();
+    res.status(200).json({message: "Deleted Succesfully!"})
+})
+
+module.exports = router;

--- a/backend/routes/interactions.js
+++ b/backend/routes/interactions.js
@@ -136,7 +136,11 @@ router.put("/update-scores", async (req, res) => {
 
 // delete current interactions (testing purposes)
 router.delete("/delete", async (req, res) => {
-  await prisma.userInteraction.deleteMany();
+  await prisma.userInteraction.deleteMany({
+    where : {
+      userId : req.session.userId,
+    }
+  });
   res.status(201).json({ message: "Deleted Successfully" });
 });
 

--- a/backend/scheduler.js
+++ b/backend/scheduler.js
@@ -1,0 +1,154 @@
+const { PrismaClient } = require("@prisma/client");
+const prisma = new PrismaClient();
+
+const WEIGHTS = {
+  READ: 3,
+  LIKED: 3,
+  OPEN: 4,
+};
+
+// functions for scheduling algorithm
+
+const aggregateMetrics = async () => {
+  const metrics = await prisma.userInteraction.findMany();
+
+  for (const interaction of metrics) {
+    const article = await prisma.globalInteraction.findFirst({
+      where: { newsId: interaction.newsId },
+    });
+
+    const newsArticle = await prisma.news.findFirst({
+      where: { id: interaction.newsId },
+    });
+
+    if (article != null) {
+      // the article is already present
+      const updatedInteraction = await prisma.globalInteraction.update({
+        data: {
+          openCount: interaction.openCount + article.openCount,
+          readCount: interaction.readCount + article.readCount,
+          likedCOunt: article.isLiked ? likedCount + 1 : likedCount,
+        },
+      });
+    } else {
+      // article is not a part of the interactions yet
+      const newInteraction = await prisma.globalInteraction.create({
+        data: {
+          // will add onto with more users
+          news: { connect: { id: interaction.newsId } },
+          openCount: interaction.openCount,
+          readCount: interaction.readCount,
+          likedCount: interaction.isLiked ? 1 : 0,
+          publishedDayOfWeek: newsArticle.releasedAt.getDay(),
+          publishedTime: newsArticle.releasedAt.getHours(),
+          score: 0.0, // default-- will add score later
+        },
+      });
+    }
+  }
+
+  const allInteractions = await prisma.globalInteraction.findMany();
+
+  return allInteractions;
+};
+
+// create date interval (Day of the week, hour) scores (group articles according to time published (same day, within two hours of each other))
+const groupByDate = async (interactions) => {
+  // news is the global interactions
+  const dateIntervals = {}; // each date interval has an averga engagement score attached (HashMap)
+  for (const interaction of interactions) {
+    const article = await prisma.news.findFirst({
+      where: { id: interaction.newsId },
+    });
+
+    const startInterval = Math.floor(interaction.publishedTime / 2) * 2; // 2-hour window
+    const endInterval = startInterval + 1;
+
+    const window = `${interaction.publishedDayOfWeek}-${startInterval
+      .toString()
+      .padStart(2, "0")}-${endInterval.toString().padStart(2, "0")}`;
+    if (!dateIntervals[window]) {
+      // this bucket doesn't exist
+      dateIntervals[window] = {
+        // key is window, value is score and count (in order to get the avg score) and categories in the bucket
+        score: interaction.score,
+        categories: article.category,
+        count: 1,
+      };
+    } else {
+      const categories = [];
+      for (const category of article.category) {
+        if (!dateIntervals[window].categories.includes(category)) {
+          categories.push(category); // new category to include
+        }
+      }
+      dateIntervals[window] = {
+        score:
+          (interaction.score + dateIntervals[window].score) /
+          (dateIntervals[window].count + 1), // new average engagement
+        count: dateIntervals[window].count + 1,
+        categories: [...dateIntervals[window].categories, ...categories], // append new categories to list of categories
+      };
+    }
+  }
+
+  return dateIntervals;
+};
+
+const getCategoryEngagement = async (interactions) => {
+  // get the engagement score averages for per category
+  const categoryScores = {};
+  for (const interaction of interactions) {
+    // from GlobalInteracions
+    const article = await prisma.news.findFirst({
+      where: { id: interaction.newsId },
+    });
+    const categories = article.category;
+    for (const category of categories) {
+      if (!categoryScores[category]) {
+        // this category does not exist
+        categoryScores[category] = {
+          score: interaction.score,
+          count: 1,
+        };
+      } else {
+        // add on
+        categoryScores[category] = {
+          score: interaction.score + categoryScores[category].score,
+          count: categoryScores[category].count + 1,
+        };
+      }
+    }
+  }
+
+  return categoryScores;
+};
+
+const groupByCategory = (dateIntervals) => {
+  // restructure date intervals according to categories
+  const categoriesOfTime = {};
+
+  const intervals = Object.keys(dateIntervals); // the intervals themselves
+
+  for (const interval of intervals) {
+    const categories = dateIntervals[interval].categories;
+    for (const category of categories) {
+      categoriesOfTime[category] = {
+        ...categoriesOfTime[category],
+        [interval]: {
+          score: dateIntervals[interval].score, // add this interval to the category
+          count: dateIntervals[interval].count,
+        },
+      };
+    }
+  }
+
+  return categoriesOfTime;
+};
+
+module.exports = {
+  aggregateMetrics,
+  groupByCategory,
+  groupByDate,
+  getCategoryEngagement,
+};

--- a/frontend/src/components/Banner.jsx
+++ b/frontend/src/components/Banner.jsx
@@ -7,25 +7,6 @@ const Banner = ({ setFilterOption, setNewsData }) => {
   const handleRefresh = () => {
     // refresh for personalized news (must update engagement scores and send personalized news back to screen)
 
-    // update engagement scores
-    fetch(`http://localhost:3000/interactions/update-scores`, {
-      method: "PUT",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-        credentials: "include",
-      },
-    })
-      .then((response) => {
-        if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
-        }
-        return response.json();
-      })
-      .catch((error) => {
-        console.error("Error updating the engagement scores: ", error);
-      });
-
     // get personalized news
     fetch(`http://localhost:3000/user-news/personalized`, {
       method: "POST",

--- a/frontend/src/components/HomePage.jsx
+++ b/frontend/src/components/HomePage.jsx
@@ -20,9 +20,7 @@ const HomePage = () => {
   const fetchNews = (url) => {
     // fetches the news for the HomePage
     fetch(url, {
-      headers: {
-        credentials: "include",
-      },
+      credentials: "include",
     })
       .then((response) => {
         if (!response.ok) {

--- a/frontend/src/components/NewsComponent.jsx
+++ b/frontend/src/components/NewsComponent.jsx
@@ -32,8 +32,8 @@ const NewsComponent = ({
       headers: {
         "Content-Type": "application/json",
         Accept: "application/json",
-        credentials: "include",
       },
+      credentials: "include",
       body: JSON.stringify({
         isBookmarked: !article.bookmarked,
       }),


### PR DESCRIPTION
- Combined fetches for calculating engagement scores and personalization
- created scheduler.js to hold functions for scheduling algorithm
- created GlobalInteraction schema to hold the aggregated metrics (openCount, readCount, etc.) of news articles across users
- - created route /find-times to find the top three times to schedule a post based on user's new post's categories only (for now)

Milestone : **Journalist Scheduling System (Technical Challenge 2)**

Test Plan: tested individual function outputs using console.logs() and routes using Insomnia for the backend. Tested frontend output for the combined fetches using localhost website

<img width="1177" height="773" alt="Screenshot 2025-07-15 at 1 41 49 PM" src="https://github.com/user-attachments/assets/f0ba287b-c99e-482a-ac5b-4cd886b876d8" />
<img width="1179" height="766" alt="Screenshot 2025-07-15 at 1 44 00 PM" src="https://github.com/user-attachments/assets/b94128e1-8548-455e-8aa1-11893c9d707b" />
