### PR TITLE
Add Annotation Functionality

### DIFF
--- a/backend/prisma/migrations/20250717203132_init_news/migration.sql
+++ b/backend/prisma/migrations/20250717203132_init_news/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - Added the required column `userId` to the `EngagementWeight` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "EngagementWeight" ADD COLUMN     "userId" INTEGER NOT NULL;
+
+-- AlterTable
+ALTER TABLE "UserNewsCache" ADD COLUMN     "canvasData" JSONB;
+
+-- AddForeignKey
+ALTER TABLE "EngagementWeight" ADD CONSTRAINT "EngagementWeight_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20250717211543_init_news/migration.sql
+++ b/backend/prisma/migrations/20250717211543_init_news/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "EngagementWeight" ALTER COLUMN "weight" SET DATA TYPE DOUBLE PRECISION;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -19,6 +19,7 @@ model User {
   password String
   interactions UserInteraction[] // user interactions per article (signals)
   userNews UserNewsCache[]
+  weights EngagementWeight[]
 }
 
 model UserInteraction {
@@ -43,6 +44,7 @@ model UserNewsCache {
   score Float // engagement score
   addedTime DateTime
   addTagInput Boolean // whether the user added their input for this specific article
+  canvasData Json? // annotations on the article
 }
 
 model Stock {
@@ -86,8 +88,10 @@ model GlobalInteraction { // aggregated engagement signals per news across users
 model EngagementWeight { // makes weights dynamic and flexible
   id       Int    @id @default(autoincrement())
   signal String
-  weight Int
+  weight Float
   updatedLast DateTime @default(now()) // just in case we need to update the weights
+  userId Int
+  user User? @relation(fields : [userId], references : [id])
 }
 
 model Feature {

--- a/backend/recommendation.js
+++ b/backend/recommendation.js
@@ -31,6 +31,7 @@ const getUserNews = async (req) => {
     newArticle.score = art.score;
     newArticle.bookmarked = art.bookmarked;
     newArticle.addTagInput = art.addTagInput;
+    newArticle.canvasData = art.canvasData;
 
     personalNews.push(newArticle);
   }

--- a/backend/recommendation.js
+++ b/backend/recommendation.js
@@ -98,10 +98,59 @@ const createPersonalizedNews = async (req, news, rankings) => {
   }
 };
 
+const changeEnagagementWeights = async (req) => {
+  const interactions = await prisma.userInteraction.findMany({ // all interactions
+    where : {userId : req.session.userId}
+  });
+
+  const prevWeights = await prisma.engagementWeight.findMany({
+    where : {userId : req.session.userId}
+  })
+
+  if (prevWeights[0].updatedLast.toDateString() === (new Date()).toDateString()) { // only want it to update daily
+    return; // not updating
+  }
+
+  // aggregate count, then update the weightage based on the proportion of engagament comes from that specific engagement
+  let openCount = 0;
+  let readCount = 0;
+  let likeCount = 0;
+  let voteCount = 0;
+  for (const interaction of interactions) {
+    openCount += interaction.openCount;
+    readCount += interaction.readCount;
+    likeCount = (interaction.isLiked) ? likeCount + 1 : likeCount;
+    voteCount = (interaction.voted) ? voteCount + 1 : voteCount;
+  }
+
+  const totalCount = openCount + readCount + likeCount + voteCount;
+
+  const weights = {
+    openCount : openCount / totalCount, // proportion of engagement done by this signal
+    readCount : readCount / totalCount,
+    isLiked : likeCount / totalCount,
+    voted : voteCount / totalCount,
+  } 
+
+  for (const signalWeight of prevWeights) {
+    const signal = signalWeight.signal;
+
+    const updatedWeight = await prisma.engagementWeight.update({
+      where : {id : signalWeight.id},
+      data : {
+        weight : (signalWeight.weight + weights[signal]).toFixed(2),
+        updatedLast : new Date()
+      }
+    })
+  }
+}
+
 const calculateEngagement = async (req) => {
   const interactions = await prisma.userInteraction.findMany({
     where: { userId: req.session.userId },
   });
+
+  await changeEnagagementWeights(req);
 
   for (const interaction of interactions) {
     // get article

--- a/backend/routes/userNews.js
+++ b/backend/routes/userNews.js
@@ -294,6 +294,33 @@ router.post("/personalized", async (req, res) => {
   }
 });
 
+// update canvas data
+router.put("/:newsId/update-canvas", async (req, res) => {
+  const { data } = req.body; // the canvas data in JSON format
+  const newsid = req.params.newsId;
+
+  try {
+    const article = await prisma.userNewsCache.findFirst({
+      where: {
+        userId: req.session.userId,
+        newsId: parseInt(newsid),
+      },
+    });
+
+    const updatedCanvas = await prisma.userNewsCache.update({
+      where: { id: article.id },
+      data: {
+        canvasData: data,
+      },
+    });
+
+    const personalNews = await getUserNews(req);
+    res.status(200).json(personalNews);
+  } catch (error) {
+    res.status(500).json({ error: "Failed to update canvas data" });
+  }
+});
+
 // delete news from the cache
 router.delete("/delete", async (req, res) => {
   await prisma.userNewsCache.deleteMany({

--- a/backend/routes/userNews.js
+++ b/backend/routes/userNews.js
@@ -284,11 +284,11 @@ router.post("/personalized", async (req, res) => {
       topRankings[i] = polled.id;
     }
 
-    await createPersonalizedNews(req, notUsedNews, topRankings);
+    // await createPersonalizedNews(req, notUsedNews, topRankings);
 
-    const personalizedNews = await getUserNews(req);
+    // const personalizedNews = await getUserNews(req);
 
-    res.status(201).json(personalizedNews);
+    res.status(201).json(topRankings);
   } catch (error) {
     res.status(500).json({ error: "Could not created personalized feed" });
   }

--- a/backend/routes/weights.js
+++ b/backend/routes/weights.js
@@ -20,6 +20,7 @@ router.post("/add-weight", async (req, res) => {
       signal: signal,
       weight: parseFloat(weight),
       updatedLast: new Date(),
+      user: { connect: { id: req.session.userId } },
     },
   });
 
@@ -32,8 +33,17 @@ router.put("/:signal/update-weight", async (req, res) => {
   const signal = req.params.signal;
   const { weight } = req.body; // the update
 
+  const original = await prisma.engagementWeight.findFirst({
+    where: {
+      signal: signal,
+      userId: req.session.userId,
+    },
+  });
+
   const updatedEngagement = await prisma.engagementWeight.update({
-    where: { signal: signal },
+    where: {
+      id: original.id,
+    },
     data: {
       weight: weight,
     },
@@ -41,6 +51,13 @@ router.put("/:signal/update-weight", async (req, res) => {
 
   const weights = await prisma.engagementWeight.findMany();
   res.status(201).json(weights);
+});
+
+// delete current weights (testing purposes)
+router.delete("/delete", async (req, res) => {
+  const deleted = await prisma.engagementWeight.deleteMany();
+
+  res.json({ message: "Deleted Successfully" });
 });
 
 module.exports = router;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1593,9 +1593,9 @@
       }
     },
     "node_modules/aproba": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
       "license": "ISC",
       "optional": true
     },
@@ -1931,9 +1931,9 @@
       }
     },
     "node_modules/decimal.js": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
-      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "license": "MIT",
       "optional": true
     },
@@ -3211,9 +3211,9 @@
       "license": "MIT"
     },
     "node_modules/nan": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.2.tgz",
-      "integrity": "sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.23.0.tgz",
+      "integrity": "sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==",
       "license": "MIT",
       "optional": true
     },

--- a/frontend/src/components/ArticleModal.jsx
+++ b/frontend/src/components/ArticleModal.jsx
@@ -32,7 +32,7 @@ const ArticleModal = (props) => {
           tagToUpdate: tag,
           addedInput: true,
         }),
-      },
+      }
     )
       .then((response) => {
         if (!response.ok) {
@@ -59,7 +59,11 @@ const ArticleModal = (props) => {
         <button className="articleButton" onClick={openArticle}>
           Article
         </button>
-        <Whiteboard />
+        <Whiteboard
+          setNewsData={props.setNewsData}
+          id={props.articleModalData.id}
+          canvasData={props.articleModalData.canvasData}
+        />
 
         <div className="userInput">
           {answered ? (

--- a/frontend/src/components/Whiteboard.jsx
+++ b/frontend/src/components/Whiteboard.jsx
@@ -1,71 +1,100 @@
-import "../styles/WhiteBoard.css";
-import { useState, useRef, useEffect } from "react";
+import { useRef, useEffect, useState } from "react";
 import { TOOLS } from "../utils/utils";
 import * as fabric from "fabric"; // v6
 
-const Whiteboard = () => {
-  const canvasRef = useRef(null);
+const Whiteboard = ({ id, canvasData, setNewsData }) => {
+  const canvasEl = useRef(null);
   const [canvas, setCanvas] = useState(null);
-  const [tool, setTool] = useState("draw"); // tools to use (default is the drawing option)
-
-  const fetchPastCanvas = () => {
-    // fetch previous annotations (if necessary)
-  };
-
-  // const resizeCanvas = () => {
-  //   canvas.setWidth(600);
-  //   canvas.setHeight(400);
-  //   canvas.renderAll();
-  // }
-
+  const [tool, setTool] = useState("draw");
   useEffect(() => {
-    const fabricCanvas = new fabric.Canvas(canvasRef.current);
+    const fabricCanvas = new fabric.Canvas(canvasEl.current, {
+      backgroundColor: "white",
+      border: "2px solid black",
+      isDrawingMode: true,
+    });
+
+    fabricCanvas.freeDrawingBrush = new fabric.PencilBrush(fabricCanvas);
     setCanvas(fabricCanvas);
 
-    fabricCanvas.renderAll();
-
-    fabricCanvas.on('path:created', (e) => {
-        console.log(e.path);
-        e.path.set({selectable : true})
-      })
+    // if a canvas already exists
+    if (canvasData) {
+      // i.e. not null
+      fabricCanvas.loadFromJSON(canvasData).then(function () {
+        fabricCanvas.renderAll();
+      });
+    }
 
     return () => {
-      fabricCanvas.dispose(); // to make sure the instance finishes initializing
-    }
+      saveCanvasData(JSON.stringify(fabricCanvas));
+      fabricCanvas.dispose();
+    };
   }, []);
 
   useEffect(() => {
-    // actual canvas functionality
     if (canvas) {
-      console.log(canvas);
-      console.log("triggered");
-      //there is a viable canvas available
-      handleTool();
-      
+      handleTool(tool);
     }
-  },[canvas, tool]);
+  }, [tool]);
 
-  const handleTool = () => {
+  const handleDelete = (obj) => {
+    const selectedObject = obj.target;
+    canvas.remove(selectedObject);
+    canvas.renderAll();
+  };
+
+  const saveCanvasData = (fabricCanvas) => {
+    fetch(`http://localhost:3000/user-news/${id}/update-canvas`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      credentials: "include",
+      body: JSON.stringify({
+        data: fabricCanvas,
+      }),
+    })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        return response.json();
+      })
+      .then((data) => {
+        setNewsData(data);
+      })
+      .catch((error) => {
+        console.error("Error setting canvas data: ", error);
+      });
+  };
+
+  const handleTool = (tool) => {
     // four main functions
-    if (tool === 'draw') {
-      console.log("drawing");
+    if (tool === "draw") {
       canvas.isDrawingMode = true;
-      canvas.freeDrawingBrush = new fabric.PencilBrush(canvas);
-      
-      // to keep the drawing on the screen
-      // canvas.freeDrawingBrush.onMouseUp();
-    } else if (tool === 'textbox') {
+      canvas.renderAll();
+    } else if (tool === "textbox") {
       canvas.isDrawingMode = false;
       let textbox = new fabric.Textbox("Type here...", {
-        left : 100,
-        right : 100,
-        width : 300,
-        editable : true, // so the user can edit the input in the textbox
-        fontSize : 18
-      })
+        left: 100,
+        right: 100,
+        width: 300,
+        editable: true, // so the user can edit the input in the textbox
+        fontSize: 18,
+      });
 
       canvas.add(textbox);
       canvas.setActiveObject(textbox); // default selected immediately
+      canvas.renderAll();
+    } else if (tool === "highlight") {
+      const obj = canvas.getActiveObject();
+      if (obj && obj.isType("Textbox")) {
+        // in editing mode textbox
+        obj.textBackgroundColor = "#FFFF00"; // highlighter yellow
+        canvas.renderAll();
+      }
+    } else if (tool === "delete") {
+      canvas.on("mouse:down", handleDelete); // whenever you click on something it deletes
     }
   };
 
@@ -73,7 +102,7 @@ const Whiteboard = () => {
     // to hold buttons to all of the actions
     return (
       <div className="whiteboardTools">
-        {Object.keys(TOOLS).map((tool) => {
+        {Object.values(TOOLS).map((tool) => {
           return <button onClick={() => setTool(tool)}>{tool}</button>;
         })}
       </div>
@@ -81,8 +110,8 @@ const Whiteboard = () => {
   };
 
   return (
-    <div className="whiteboard">
-      <canvas width="600px" height="400px" ref={canvasRef}></canvas>
+    <div className="whiteboardStuff">
+      <canvas width="600" height="400" ref={canvasEl} />
       <Toolbar />
     </div>
   );

--- a/frontend/src/components/Whiteboard.jsx
+++ b/frontend/src/components/Whiteboard.jsx
@@ -1,21 +1,89 @@
 import "../styles/WhiteBoard.css";
 import { useState, useRef, useEffect } from "react";
+import { TOOLS } from "../utils/utils";
 import * as fabric from "fabric"; // v6
 
 const Whiteboard = () => {
   const canvasRef = useRef(null);
   const [canvas, setCanvas] = useState(null);
+  const [tool, setTool] = useState("draw"); // tools to use (default is the drawing option)
+
+  const fetchPastCanvas = () => {
+    // fetch previous annotations (if necessary)
+  };
+
+  // const resizeCanvas = () => {
+  //   canvas.setWidth(600);
+  //   canvas.setHeight(400);
+  //   canvas.renderAll();
+  // }
 
   useEffect(() => {
     const fabricCanvas = new fabric.Canvas(canvasRef.current);
     setCanvas(fabricCanvas);
 
-    fabricCanvas.dispose(); // to make sure the instance finishes initializing
+    fabricCanvas.renderAll();
+
+    fabricCanvas.on('path:created', (e) => {
+        console.log(e.path);
+        e.path.set({selectable : true})
+      })
+
+    return () => {
+      fabricCanvas.dispose(); // to make sure the instance finishes initializing
+    }
   }, []);
+
+  useEffect(() => {
+    // actual canvas functionality
+    if (canvas) {
+      console.log(canvas);
+      console.log("triggered");
+      //there is a viable canvas available
+      handleTool();
+      
+    }
+  },[canvas, tool]);
+
+  const handleTool = () => {
+    // four main functions
+    if (tool === 'draw') {
+      console.log("drawing");
+      canvas.isDrawingMode = true;
+      canvas.freeDrawingBrush = new fabric.PencilBrush(canvas);
+      
+      // to keep the drawing on the screen
+      // canvas.freeDrawingBrush.onMouseUp();
+    } else if (tool === 'textbox') {
+      canvas.isDrawingMode = false;
+      let textbox = new fabric.Textbox("Type here...", {
+        left : 100,
+        right : 100,
+        width : 300,
+        editable : true, // so the user can edit the input in the textbox
+        fontSize : 18
+      })
+
+      canvas.add(textbox);
+      canvas.setActiveObject(textbox); // default selected immediately
+    }
+  };
+
+  const Toolbar = () => {
+    // to hold buttons to all of the actions
+    return (
+      <div className="whiteboardTools">
+        {Object.keys(TOOLS).map((tool) => {
+          return <button onClick={() => setTool(tool)}>{tool}</button>;
+        })}
+      </div>
+    );
+  };
 
   return (
     <div className="whiteboard">
       <canvas width="600px" height="400px" ref={canvasRef}></canvas>
+      <Toolbar />
     </div>
   );
 };

--- a/frontend/src/styles/WhiteBoard.css
+++ b/frontend/src/styles/WhiteBoard.css
@@ -2,4 +2,5 @@ canvas {
   border: 2px solid black;
   margin: 10px;
   background-color: white;
+  color:black;
 }

--- a/frontend/src/utils/utils.js
+++ b/frontend/src/utils/utils.js
@@ -24,3 +24,10 @@ export const CATEGORIES = {
   FOOD: "food",
   TRAVEL: "travel",
 }
+
+export const TOOLS = {
+  TEXTBOX : "textbox",
+  DRAW: "draw",
+  HIGHLIGHT : "highlight",
+  DELETE : "delete"
+}


### PR DESCRIPTION
- Added changeEngagementWeights in order to dynamically change the weights of user signals according to how often the user uses each signal (Technical Challenge 1)
- - EngagementWeight schema holds these values per user
- Modified Canvas functionality to accept a freeDrawingBrush (for drawing functionality)
- - default is drawing
-  Added tool buttons for highlighting, textbox, drawing, and deleting functionality
- Created route update-canvas in userNewsCache in order to save changes to the canvas for the user for the specific article
- - call before disposing of canvas so we can refresh the page or venture away from the whiteboard and the annotations are still present

Milestone : **Annotations**

Test Plan: Tested updates to the canvas using GET request for userNews (to make sure the right JSON is being sent to the userNewsCache), tested frontend functionality through console.logs() on localhost website

<div>
    <a href="https://www.loom.com/share/1d1bc25a5a544156910c07c351441f55">
      <p>Vite + React - 18 July 2025 - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/1d1bc25a5a544156910c07c351441f55">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/1d1bc25a5a544156910c07c351441f55-e666070263b604f3-full-play.gif">
    </a>
  </div>
<img width="1173" height="771" alt="Screenshot 2025-07-18 at 10 55 40 AM" src="https://github.com/user-attachments/assets/cbe0b180-53f5-44f1-98bd-4df9b2a659d5" />