### PR TITLE
Brought Fact-Checking to Frontend and Integrated with Searching

### DIFF
--- a/backend/prisma/migrations/20250729180715_init_news/migration.sql
+++ b/backend/prisma/migrations/20250729180715_init_news/migration.sql
@@ -1,0 +1,10 @@
+-- CreateTable
+CREATE TABLE "FactEvidence" (
+    "id" SERIAL NOT NULL,
+    "claim" TEXT NOT NULL,
+    "reviewer" TEXT NOT NULL,
+    "review" TEXT NOT NULL,
+    "reviewDate" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FactEvidence_pkey" PRIMARY KEY ("id")
+);

--- a/backend/prisma/migrations/20250729182328_init_news/migration.sql
+++ b/backend/prisma/migrations/20250729182328_init_news/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the `FactEvidence` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE "FactEvidence";

--- a/frontend/src/components/FactComponent.jsx
+++ b/frontend/src/components/FactComponent.jsx
@@ -1,0 +1,28 @@
+import "../styles/FactComponent.css";
+
+const FactComponent = ({ article }) => {
+  const openArticle = () => {
+    const url = article.articleURL;
+    window.open(url, "_blank");
+  };
+
+  const parseDate = (date) => {
+    const newDate = new Date(date);
+    newDate.setHours(newDate.getHours() + newDate.getTimezoneOffset() / 60);
+
+    return newDate.toDateString();
+  };
+
+  return (
+    <div className="evidence" onClick={openArticle}>
+      <h2>Claim: {article.claim}</h2>
+      <h3>Review : {article.review}</h3>
+      <div className="details">
+        <h4>Source : {article.source}</h4>
+        <h4>Published On : {parseDate(article.reviewDate)}</h4>
+      </div>
+    </div>
+  );
+};
+
+export default FactComponent;

--- a/frontend/src/components/HomePage.jsx
+++ b/frontend/src/components/HomePage.jsx
@@ -3,12 +3,16 @@ import Banner from "../components/Banner.jsx";
 import NewsList from "./NewsList";
 import LoadingGif from "../assets/loading.gif";
 import PersonalizationModal from "./PersonalizationModal.jsx";
+import SearchBar from "./SearchBar.jsx";
 
 const HomePage = () => {
   const [newsData, setNewsData] = useState(null);
-  const [personalModal, setPersonalModal] = useState(false); // whether or not we need the modal for initial personalization
+  const [originalData, setOriginalData] = useState(null);
+  const [personalModalVisible, setPersonalModalVisible] = useState(false); // whether or not we need the modal for initial personalization
   const [isLoading, setLoading] = useState(null);
+  const [fromFact, setFromFact] = useState(false); // test whether the newsData is from fact search query
   const [filterOption, setFilterOption] = useState(""); // for the filter dropdown
+  
   const fetchNewsURL = `http://localhost:3000/user-news`; // default URL for general news (but user-specific)
 
   useEffect(() => {
@@ -36,9 +40,10 @@ const HomePage = () => {
       .then((data) => {
         if (data.length === 0) {
           // there is no news in the cache for this specific user (i.e. new user)
-          setPersonalModal(true);
+          setPersonalModalVisible(true);
         } else {
           setNewsData(data);
+          setOriginalData(data);
         }
         setLoading(false);
       })
@@ -60,13 +65,14 @@ const HomePage = () => {
         setNewsData={setNewsData}
         setLoading={setLoading}
       />
-      {personalModal && (
+      <SearchBar originalData={originalData} setNewsData={setNewsData} setFromFact={setFromFact}/>
+      {personalModalVisible && (
         <PersonalizationModal
           setNewsData={setNewsData}
-          setPersonalModal={setPersonalModal}
+          setPersonalModalVisible={setPersonalModalVisible}
         />
       )}
-      {newsData && <NewsList newsData={newsData} setNewsData={setNewsData} />}
+      {newsData && <NewsList newsData={newsData} setNewsData={setNewsData} fromFact={fromFact} />}
       <div className="loading-state">
         {isLoading && (
           <img className="loading" src={LoadingGif} alt="Loading . . ." />

--- a/frontend/src/components/NewsList.jsx
+++ b/frontend/src/components/NewsList.jsx
@@ -1,9 +1,10 @@
 import NewsComponent from "./NewsComponent";
 import ArticleModal from "./ArticleModal";
+import FactComponent from './FactComponent'
 import { useState } from "react";
 import "../styles/News.css";
 
-const NewsList = ({ newsData, setNewsData }) => {
+const NewsList = ({ newsData, setNewsData, fromFact }) => {
   const [articleModalData, setArticleModalData] = useState(""); // for the article data (just the article link for now)
 
   const handleSignalUpdates = (id, signal, liked) => {
@@ -39,16 +40,25 @@ const NewsList = ({ newsData, setNewsData }) => {
           handleSignalUpdates={handleSignalUpdates}
         />
       )}
-      {newsData.map((article) => {
-        return (
-          <NewsComponent
-            article={article}
-            setNewsData={setNewsData}
-            setArticleModalData={setArticleModalData}
-            handleSignalUpdates={handleSignalUpdates}
-          />
-        );
-      })}
+      {!fromFact &&
+        newsData.map((article) => {
+          return (
+            <NewsComponent
+              article={article}
+              setNewsData={setNewsData}
+              setArticleModalData={setArticleModalData}
+              handleSignalUpdates={handleSignalUpdates}
+            />
+          );
+        })}
+
+      {fromFact &&
+        newsData.map((article) => {
+          return (
+            // not the same as the news component (does not have all of the signal functionality)
+            <FactComponent article={article} />
+          );
+        })}
     </div>
   );
 };

--- a/frontend/src/components/PersonalizationModal.jsx
+++ b/frontend/src/components/PersonalizationModal.jsx
@@ -2,7 +2,7 @@ import "../styles/modal.css";
 import { useState } from "react";
 import { CATEGORIES } from "../utils/utils.js";
 
-const PersonalizationModal = ({ setNewsData, setPersonalModal }) => {
+const PersonalizationModal = ({ setNewsData, setPersonalModalVisible }) => {
   const [personal, setPersonal] = useState({
     categories: [], // set kind of categories to choose from
     sources: [], // user can input whatever sources they would like
@@ -38,7 +38,7 @@ const PersonalizationModal = ({ setNewsData, setPersonalModal }) => {
       })
       .catch((error) => {
         setLoading(false);
-        setPersonalModal(false);
+        setPersonalModalVisible(false);
         console.error("Error fetching Personalized News: ", error);
       });
   };

--- a/frontend/src/components/SearchBar.jsx
+++ b/frontend/src/components/SearchBar.jsx
@@ -1,0 +1,99 @@
+import { useState } from "react";
+import "../styles/SearchBar.css";
+
+const SearchBar = ({ originalData, setNewsData, setFromFact }) => {
+  const [query, setQuery] = useState("");
+  const [isFactCheck, setIsFactCheck] = useState(false); // to toggle between fact-checking and simply searching for specific articles
+
+  const handleSearching = (event) => {
+    event.preventDefault();
+    if (isFactCheck) {
+      fetch(`http://localhost:3000/news/fact-checked`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        credentials: "include",
+        body: JSON.stringify({
+          claim: query,
+        }),
+      })
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+          }
+          return response.json();
+        })
+        .then((data) => {
+          setNewsData(data); // NOT the same structure as the other news, must be handled separately
+          setFromFact(true); // once the information is accessed, will set this back to false
+        })
+        .catch((error) => {
+          console.error("Error fetching evidence:", error);
+        });
+    } else {
+      // normal searching through the information presented on the screen
+      const filteredNews = [];
+
+      const newsData = originalData;
+      const keyWords = query.split(" "); // split the query into keywords to look for
+
+      for (const article of newsData) {
+        if (
+          keyWords.some((word) =>
+            article.name.toLowerCase().includes(word.toLowerCase())
+          )
+        ) {
+          // accounts for case-insensitivity
+          // valid article
+          filteredNews.push(article);
+        }
+      }
+
+      setNewsData(filteredNews);
+    }
+  };
+
+  const TypeOfSearch = () => {
+    return (
+      <div
+        className="type-search"
+        onClick={() => setIsFactCheck(!isFactCheck)}
+        style={{ backgroundColor: isFactCheck ? "#9e0b0f" : "#000000" }}
+      >
+        {isFactCheck ? "Fact Check" : "Search Articles"}
+      </div>
+    );
+  };
+
+  const handleClear = () => {
+    setFromFact(false); // reset the information on the Home Page
+    setNewsData(originalData); // reset the news data to the original news data passed into this component
+  };
+
+  return (
+    <form className="Searchbar" onSubmit={handleSearching}>
+      <div className="formElements">
+        <TypeOfSearch />
+
+        <input
+          className="searchInput"
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Ask a question or fact-check a claim..."
+        />
+
+        <button type="submit" id="submitChange" onClick={handleSearching}>
+          Search
+        </button>
+        <button type="button" id="submitChange" onClick={handleClear}>
+          Clear
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default SearchBar;

--- a/frontend/src/styles/FactComponent.css
+++ b/frontend/src/styles/FactComponent.css
@@ -1,0 +1,16 @@
+.evidence {
+    display:flex;
+    flex-direction:column;
+    border:3px solid #9e0b0f;
+    padding:10px;
+    margin:10px;
+    max-height: auto;
+    max-width: 370px;
+    transition: background-color 0.3s ease-in-out;
+}
+
+.evidence:hover {
+    color:white;
+    background-color:black;
+    cursor:pointer
+}

--- a/frontend/src/styles/SearchBar.css
+++ b/frontend/src/styles/SearchBar.css
@@ -1,0 +1,22 @@
+.Searchbar {
+    display:flex;
+    background-color:#ababab;
+    border:2px solid black;
+    border-radius:0%;
+}
+
+.searchInput {
+    margin:10px;
+    width:80%auto;
+    height:40px;
+}
+
+.type-search {
+    padding:5px;
+    color:white;
+    border:1px solid black;
+}
+
+#submitChange {
+    margin:5px;
+}


### PR DESCRIPTION
- Added search bar for both fact-checking and searching through existed user-specific news
- - Toggle between both usages by clicking on button above search bar (adjusts news-list input accordingly)
- Adjusted fact-checking route to clean JSON output from API, isolating the claim, review, reviewDate, publisher, and the url of the article
- When a fact is entered (in fact-checking mode), the articles and their subsequent information are displayed
- - clicking on an article opens into the full article (via the url)
- clear button brings user back to original user-specific news
- When the user is in searching mode, search for keyword matches with the articles in the userNewsCache for the specific user and present the matches

Milestone : **Fact-Checking Search Bar (Stretch Goal)**

Test Plan: Tested backend route using Insomnia and frontend integration using localhost website

<div>
    <a href="https://www.loom.com/share/e6fbd09e1a464469813895bce6e0ffe3">
      <p>Vite + React - 29 July 2025 - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/e6fbd09e1a464469813895bce6e0ffe3">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/e6fbd09e1a464469813895bce6e0ffe3-afa993ea58dbda2e-full-play.gif">
    </a>
  </div>
<img width="1173" height="726" alt="Screenshot 2025-07-29 at 11 21 41 AM" src="https://github.com/user-attachments/assets/ade25252-115c-47a8-ab18-5b2a387a4989" />